### PR TITLE
Refactor Region and CIDR Block Settings in Crossplane Configuration

### DIFF
--- a/infrastructure/base/crossplane/configuration/environmentconfig.yaml
+++ b/infrastructure/base/crossplane/configuration/environmentconfig.yaml
@@ -10,4 +10,5 @@ data:
   accountId: ${aws_account_id}
   region: ${region}
   vpcId: ${vpc_id}
+  CIDRBlock: ${vpc_cidr_block}
   privateSubnetIds: ${private_subnet_ids}

--- a/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
@@ -35,9 +35,9 @@ spec:
                 type: FromCompositeFieldPath
           - name: region
             patches:
-              - fromFieldPath: spec.parameters.region
+              - fromFieldPath: region
                 toFieldPath: spec.forProvider.region
-                type: FromCompositeFieldPath
+                type: FromEnvironmentFieldPath
 
         resources:
           - base:
@@ -100,9 +100,9 @@ spec:
                 type: PatchSet
               - patchSetName: region
                 type: PatchSet
-              - fromFieldPath: spec.parameters.allowedCIDR
+              - fromFieldPath: CIDRBlock
                 toFieldPath: spec.forProvider.cidrIpv4
-                type: FromCompositeFieldPath
+                type: FromEnvironmentFieldPath
               - fromFieldPath: spec.parameters.dbPort
                 toFieldPath: spec.forProvider.toPort
                 type: FromCompositeFieldPath

--- a/infrastructure/base/crossplane/configuration/sql-instance-definition.yaml
+++ b/infrastructure/base/crossplane/configuration/sql-instance-definition.yaml
@@ -30,9 +30,6 @@ spec:
                 parameters:
                   type: object
                   properties:
-                    region:
-                      type: string
-                      description: Region is the region you'd like your resource to be created in.
                     deletionPolicy:
                       description: Delete the external resources when the Claim/XR is deleted. Defaults to Delete
                       enum:
@@ -78,9 +75,6 @@ spec:
                         - key
                     autoGeneratePassword:
                       type: boolean
-                    allowedCIDR:
-                      type: string
-                      description: "The CIDR to allow access to the RDS instance"
                     subnetIds:
                       type: array
                       description: "A list of the subnet IDs where the database will be provision"
@@ -105,13 +99,11 @@ spec:
                           - name
                           - owner
                   required:
-                    - region
                     - engine
                     - engineVersion
                     - size
                     - storageGB
                     - passwordSecretRef
-                    - allowedCIDR
               required:
                 - parameters
             status:

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -23,7 +23,7 @@ variable "cluster_version" {
 
 variable "cilium_version" {
   description = "Cilium cluster version"
-  default     = "1.14.4"
+  default     = "1.14.5"
   type        = string
 }
 

--- a/tooling/base/harbor/sqlinstance.yaml
+++ b/tooling/base/harbor/sqlinstance.yaml
@@ -5,12 +5,10 @@ metadata:
   namespace: tooling
 spec:
   parameters:
-    region: ${region}
     engine: postgres
     engineVersion: "15"
     size: small
     storageGB: 20
-    allowedCIDR: ${vpc_cidr_block}
     databases:
       - owner: harbor
         name: registry


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR simplifies the Crossplane configuration by automatically setting the region and CIDR block from the EKS cluster. The main changes include:
- The Cilium cluster version default value has been updated in the EKS variables.
- The region and CIDR block are now fetched from the environment in the SQL instance composition.
- The region and allowedCIDR parameters have been removed from the SQL instance definition.
- The region and allowedCIDR parameters have been removed from the SQL instance in the Harbor configuration.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        terraform/eks/variables.tf<br><br>
        <strong>The default version of the Cilium cluster has been updated <br>from 1.14.4 to 1.14.5.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/34/files#diff-03a38e8def3f0b3f9d73cf5d2448da8616011aac36679094c516236136f19afd"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>environmentconfig.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        infrastructure/base/crossplane/configuration/environmentconfig.yaml<br><br>
        <strong>The CIDR block has been added to the environment <br>configuration.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/34/files#diff-8dbd5964465b844d13e6c0c6600e6c64eb22ad6f4368232b065df234abf60ac8"> +1/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sql-instance-composition.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        infrastructure/base/crossplane/configuration/sql-instance-composition.yaml<br><br>
        <strong>The region and CIDR block are now fetched from the <br>environment instead of the composite field path.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/34/files#diff-6e164a2dff857f0dd9c65601b0108471d18aa7b3aafb4367c770a134b1f169bc"> +4/-4</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sql-instance-definition.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        infrastructure/base/crossplane/configuration/sql-instance-definition.yaml<br><br>
        <strong>The region and allowedCIDR parameters have been removed from <br>the SQL instance definition.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/34/files#diff-d983d77acc144853afdb471a7a40ac6641243158459b2e58f652f0e3204df556"> +0/-8</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sqlinstance.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        tooling/base/harbor/sqlinstance.yaml<br><br>
        <strong>The region and allowedCIDR parameters have been removed from <br>the SQL instance in the Harbor configuration.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/34/files#diff-fe7ab071d7f4bea2bd7b1fb404dd24930eef11c0a5483b22cd2f6d04334e760f"> +0/-2</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>