### PR TITLE
Fix Vault startup scripts and auto-unseal with ephemeral disks setup

### DIFF
--- a/terraform/vault/scripts/startup_script.sh
+++ b/terraform/vault/scripts/startup_script.sh
@@ -50,12 +50,13 @@ storage "raft" {
     leader_ca_cert_file     = "/opt/vault/tls/ca.pem"
   }
 }
+%{ endif }
 
 seal "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_unseal_key_id}"
 }
-%{ endif }
+
 EOF
 
 systemctl start vault.service


### PR DESCRIPTION
## Type
Bug fix


___

## Description
This PR includes two main changes:
- The `setup-local-disks.sh` script has been updated to check if there are any ephemeral disks before proceeding with the setup. If there are no disks, the script will skip the setup. If disks are found, the script will ensure it is being run as root, then proceed to set up RAID-0 on the ephemeral disks.
- The `startup_script.sh` has been updated to ensure the correct sequence of operations. The 'seal' block for AWS KMS is now correctly placed within the conditional block.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup-local-disks.sh&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        terraform/vault/scripts/setup-local-disks.sh<br><br>

**The script has been updated to check if there are any <br>ephemeral disks before proceeding with the setup. If there <br>are no disks, the script will skip the setup. If disks are <br>found, the script will ensure it is being run as root, then <br>proceed to set up RAID-0 on the ephemeral disks.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/71/files#diff-6e59c891faab02a197a1088a85947e14bf0451b77e12701a268518e9f15cd367"> +8/-10</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>startup_script.sh&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        terraform/vault/scripts/startup_script.sh<br><br>

**The startup script has been updated to ensure the correct <br>sequence of operations. The 'seal' block for AWS KMS is now <br>correctly placed within the conditional block.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/71/files#diff-361b821170fb13dd5345ad16670cf9083245b598d316c4c9b7c39b0963196aa4"> +2/-1</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>