### PR TITLE
feat(eks): EKS Pod Identity Crossplane Composition

### DIFF
--- a/infrastructure/base/crossplane/configuration/epi-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/epi-composition.yaml
@@ -1,0 +1,218 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  creationTimestamp: "2024-02-18T18:06:04Z"
+  name: xepis.cloud.ogenki.io
+spec:
+  compositeTypeRef:
+    apiVersion: cloud.ogenki.io/v1alpha1
+    kind: XEPI
+  environment:
+    environmentConfigs:
+      - ref:
+          name: eks-environment
+        type: Reference
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        patchSets:
+          - name: Name
+            patches:
+              - fromFieldPath: metadata.name
+                toFieldPath: metadata.annotations[crossplane.io/external-name]
+                type: FromCompositeFieldPath
+              - fromFieldPath: metadata.labels[crossplane.io/claim-name]
+                toFieldPath: metadata.annotations[crossplane.io/external-name]
+                type: FromCompositeFieldPath
+          - name: providerConfigRef
+            patches:
+              - fromFieldPath: spec.providerConfigRef.name
+                toFieldPath: spec.providerConfigRef.name
+                type: FromCompositeFieldPath
+          - name: deletionPolicy
+            patches:
+              - fromFieldPath: spec.deletionPolicy
+                toFieldPath: spec.deletionPolicy
+                type: FromCompositeFieldPath
+          - name: region
+            patches:
+              - fromFieldPath: region
+                toFieldPath: spec.forProvider.region
+                type: FromEnvironmentFieldPath
+        resources:
+          - name: iam-role
+            base:
+              apiVersion: iam.aws.upbound.io/v1beta1
+              kind: Role
+              metadata:
+                labels:
+                  resource: Role
+              spec:
+                forProvider:
+                  assumeRolePolicy: |
+                    {
+                      "Version": "2012-10-17",
+                      "Statement": [
+                        {
+                          "Effect": "Allow",
+                          "Principal": {
+                            "Service": "pods.eks.amazonaws.com"
+                          },
+                          "Action": [
+                            "sts:AssumeRole",
+                            "sts:TagSession"
+                          ]
+                        }
+                      ]
+                    }
+            patches:
+              - patchSetName: Name
+                type: PatchSet
+              - patchSetName: providerConfigRef
+                type: PatchSet
+              - patchSetName: deletionPolicy
+                type: PatchSet
+              - fromFieldPath: status.atProvider.arn
+                policy:
+                  fromFieldPath: Optional
+                toFieldPath: status.roleArn
+                type: ToCompositeFieldPath
+              - fromFieldPath: status.conditions
+                policy:
+                  fromFieldPath: Optional
+                toFieldPath: status.observed.role.conditions
+                type: ToCompositeFieldPath
+              - fromFieldPath: metadata.annotations[serviceAccount/namespace]
+                toFieldPath: serviceAccount.namespace
+                type: ToEnvironmentFieldPath
+              - fromFieldPath: metadata.annotations[serviceAccount/name]
+                toFieldPath: serviceAccount.name
+                type: ToEnvironmentFieldPath
+
+          - name: iam-policy
+            base:
+              apiVersion: iam.aws.upbound.io/v1beta1
+              kind: Policy
+              metadata:
+                labels:
+                  resource: Policy
+            patches:
+              - patchSetName: providerConfigRef
+                type: PatchSet
+              - patchSetName: deletionPolicy
+                type: PatchSet
+              - fromFieldPath: spec.parameters.policyDocument
+                toFieldPath: spec.forProvider.policy
+                type: FromCompositeFieldPath
+              - fromFieldPath: metadata.annotations[crossplane.io/external-name]
+                toFieldPath: status.policyArn
+                type: ToCompositeFieldPath
+              - fromFieldPath: status.conditions
+                policy:
+                  fromFieldPath: Optional
+                toFieldPath: status.observed.policy.conditions
+                type: ToCompositeFieldPath
+
+          - name: iam-policy-attachment
+            base:
+              apiVersion: iam.aws.upbound.io/v1beta1
+              kind: RolePolicyAttachment
+              metadata:
+                labels:
+                  resource: RolePolicyAttachment
+              spec:
+                forProvider:
+                  policyArnSelector:
+                    matchControllerRef: true
+                    matchLabels:
+                      resource: Policy
+                  roleSelector:
+                    matchControllerRef: true
+                    matchLabels:
+                      resource: Role
+            patches:
+              - patchSetName: providerConfigRef
+                type: PatchSet
+              - patchSetName: deletionPolicy
+                type: PatchSet
+              - fromFieldPath: status.conditions
+                policy:
+                  fromFieldPath: Optional
+                toFieldPath: status.observed.rpa.conditions
+                type: ToCompositeFieldPath
+
+          - name: eks-pod-identity-association
+            base:
+              apiVersion: eks.aws.upbound.io/v1beta1
+              kind: PodIdentityAssociation
+              metadata:
+                labels:
+                  resource: EKSPodIdentityAssociation
+              spec:
+                forProvider:
+                  roleArnSelector:
+                    matchControllerRef: true
+                    matchLabels:
+                      resource: Role
+            patches:
+              - patchSetName: providerConfigRef
+                type: PatchSet
+              - patchSetName: deletionPolicy
+                type: PatchSet
+              - patchSetName: region
+                type: PatchSet
+              - fromFieldPath: spec.parameters.clusterName
+                toFieldPath: spec.forProvider.clusterName
+                type: FromCompositeFieldPath
+              - fromFieldPath: spec.parameters.serviceAccount.name
+                toFieldPath: spec.forProvider.serviceAccount
+                type: FromCompositeFieldPath
+              - fromFieldPath: spec.parameters.serviceAccount.namespace
+                toFieldPath: spec.forProvider.namespace
+                type: FromCompositeFieldPath
+              - fromFieldPath: status.conditions
+                policy:
+                  fromFieldPath: Optional
+                toFieldPath: status.observed.rpa.conditions
+                type: ToCompositeFieldPath
+
+    - step: additional-policies
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{ $claim  	:= .observed.composite.resource }}
+            {{ $parameters := .observed.composite.resource.spec.parameters }}
+
+            {{- range $key, $value := $parameters.additionalPolicyArns }}
+            ---
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: RolePolicyAttachment
+            metadata:
+              name: "{{ index $claim.spec.claimRef "name" }}-{{ $key | lower }}"
+              annotations:
+                {{ setResourceNameAnnotation (print "rpa-" (replace "_" "-" $key | lower)) }}
+            spec:
+              deletionPolicy: {{ default "Delete" (index $parameters "deletionPolicy") }}
+              forProvider:
+                policyArn: {{ $value }}
+                roleSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    resource: Role
+              providerConfigRef:
+                name: default
+            {{- end }}
+
+    - step: ready
+      functionRef:
+        name: function-auto-ready

--- a/infrastructure/base/crossplane/configuration/epi-definition.yaml
+++ b/infrastructure/base/crossplane/configuration/epi-definition.yaml
@@ -1,0 +1,86 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xepis.cloud.ogenki.io
+  labels:
+    provider: aws
+spec:
+  claimNames:
+    kind: EPI
+    plural: epis
+  group: cloud.ogenki.io
+  names:
+    kind: XEPI
+    plural: xepis
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  description: EKS Pod Identity parameters.
+                  properties:
+                    clusterName:
+                      type: string
+                      description: Name of the EKS cluster to create the pod identity association with
+                    serviceAccount:
+                      type: object
+                      description: Configuration for SA
+                      properties:
+                        name:
+                          type: string
+                          description: name kubernetes SA
+                        namespace:
+                          type: string
+                          description: namespace kubernetes SA
+                      required:
+                        - name
+                        - namespace
+                    policyDocument:
+                      type: string
+                      description: The JSON policy document that is the content for the policy.
+                    additionalPolicyArns:
+                      description: Object containing key-value pairs for additional policies.
+                      type: object
+                      additionalProperties:
+                        type: string
+                  required:
+                    - clusterName
+                    - policyDocument
+                    - serviceAccount
+                deletionPolicy:
+                  type: string
+                  description: DeletionPolicy specifies what will happen to the underlying external when this managed resource is deleted - either "Delete" or "Orphan" the external resource.
+                providerConfigRef:
+                  type: object
+                  description: crossplane provider credentials to use.
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                AssociationArn:
+                  description: The ARN of the Pod Identity Association
+                  type: string
+                roleArn:
+                  description: The ARN of the role
+                  type: string
+                policyArn:
+                  description: The ARN of the policy
+                  type: string
+                observed:
+                  description: Freeform field containing information about the observed status.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true

--- a/infrastructure/base/crossplane/configuration/kustomization.yaml
+++ b/infrastructure/base/crossplane/configuration/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: crossplane-system
 
 resources:
   - environmentconfig.yaml
+  - epi-composition.yaml
+  - epi-definition.yaml
   - function-auto-ready.yaml
   - function-patch-and-transform.yaml
   - function-go-templating.yaml

--- a/infrastructure/base/crossplane/providers/kustomization.yaml
+++ b/infrastructure/base/crossplane/providers/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - controllerconfig-k8s.yaml
   - deploymentruntimeconfig-aws.yaml
   - provider-ec2.yaml
+  - provider-eks.yaml
   - provider-iam.yaml
   - provider-kms.yaml
   - provider-kubernetes.yaml

--- a/infrastructure/base/crossplane/providers/provider-ec2.yaml
+++ b/infrastructure/base/crossplane/providers/provider-ec2.yaml
@@ -3,7 +3,7 @@ kind: Provider
 metadata:
   name: provider-aws-ec2
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-ec2:v0.47.1
+  package: xpkg.upbound.io/upbound/provider-aws-ec2:v1.1.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/infrastructure/base/crossplane/providers/provider-eks.yaml
+++ b/infrastructure/base/crossplane/providers/provider-eks.yaml
@@ -1,9 +1,9 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-aws-iam
+  name: provider-aws-eks
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.1.0
+  package: xpkg.upbound.io/upbound/provider-aws-eks:v1.1.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/infrastructure/base/crossplane/providers/provider-kms.yaml
+++ b/infrastructure/base/crossplane/providers/provider-kms.yaml
@@ -3,7 +3,7 @@ kind: Provider
 metadata:
   name: provider-aws-kms
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-kms:v0.47.1
+  package: xpkg.upbound.io/upbound/provider-aws-kms:v1.1.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/infrastructure/base/crossplane/providers/provider-kubernetes.yaml
+++ b/infrastructure/base/crossplane/providers/provider-kubernetes.yaml
@@ -3,6 +3,6 @@ kind: Provider
 metadata:
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.9.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.11.4
   controllerConfigRef:
     name: provider-kubernetes

--- a/infrastructure/base/crossplane/providers/provider-s3.yaml
+++ b/infrastructure/base/crossplane/providers/provider-s3.yaml
@@ -3,7 +3,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.1
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/observability/base/loki/helmrelease.yaml
+++ b/observability/base/loki/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: grafana
         namespace: observability
-      version: "5.35.0"
+      version: "5.43.2"
   interval: 4m0s
   timeout: 10m
   install:
@@ -22,9 +22,6 @@ spec:
     crds: CreateReplace
   values:
     fullNameOverride: loki
-    serviceAccount:
-      annotations:
-        eks.amazonaws.com/role-arn: "arn:aws:iam::${aws_account_id}:role/xplane-loki-${cluster_name}"
     loki:
       auth_enabled: false
       storage:

--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: 27b1aa2e-cf1a-d3b7-058e-ddf502d468a0 # !! This value changes each time I recreate the whole platform
+        roleId: 6bb64411-7fda-a6bf-60e7-baccfe7dcbcf # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secretId

--- a/security/base/external-secrets/clustersecretstore.yaml
+++ b/security/base/external-secrets/clustersecretstore.yaml
@@ -5,11 +5,6 @@ metadata:
 spec:
   provider:
     aws:
-      auth:
-        jwt:
-          serviceAccountRef:
-            name: external-secrets
-            namespace: security
       region: ${region}
       service: SecretsManager
   refreshInterval: 0

--- a/security/base/external-secrets/epi.yaml
+++ b/security/base/external-secrets/epi.yaml
@@ -1,12 +1,14 @@
 apiVersion: cloud.ogenki.io/v1alpha1
-kind: IRSA
+kind: EPI
 metadata:
     name: xplane-external-secrets-${cluster_name}
     namespace: security
 spec:
-    deletionPolicy: Delete
     parameters:
-        condition: StringEquals
+        clusterName: ${cluster_name}
+        serviceAccount:
+            name: external-secrets
+            namespace: security
         # Reference: https://github.com/external-secrets/external-secrets/blob/main/terraform/aws/modules/cluster/irsa.tf
         policyDocument: |
             {
@@ -26,6 +28,3 @@ spec:
                     }
                 ]
             }
-        serviceAccount:
-            name: external-secrets
-            namespace: security

--- a/security/base/external-secrets/helmrelease.yaml
+++ b/security/base/external-secrets/helmrelease.yaml
@@ -21,8 +21,6 @@ spec:
   values:
     replicaCount: 1
     serviceAccount:
-      annotations:
-        eks.amazonaws.com/role-arn: "arn:aws:iam::${aws_account_id}:role/xplane-external-secrets-${cluster_name}"
       name: "external-secrets"
 
     installCRDs: false

--- a/security/base/external-secrets/kustomization.yaml
+++ b/security/base/external-secrets/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 
 resources:
   - clustersecretstore.yaml
-  - irsa.yaml
+  - epi.yaml
   - helmrelease.yaml
   - source.yaml

--- a/terraform/eks/irsa.tf
+++ b/terraform/eks/irsa.tf
@@ -29,6 +29,7 @@ module "irsa_crossplane" {
 
   role_policy_arns = {
     ec2  = aws_iam_policy.crossplane_ec2.arn,
+    eks  = aws_iam_policy.crossplane_eks.arn,
     irsa = aws_iam_policy.crossplane_irsa.arn,
     kms  = aws_iam_policy.crossplane_kms.arn,
     rds  = aws_iam_policy.crossplane_rds.arn
@@ -112,6 +113,31 @@ resource "aws_iam_policy" "crossplane_ec2" {
                 "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
                 "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
                 "ec2:CreateTags"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_policy" "crossplane_eks" {
+  name        = "crossplane_eks_${var.cluster_name}"
+  path        = "/"
+  description = "Policy for managing EKS Pod identities"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "eks:DescribePodIdentityAssociation",
+                "eks:CreatePodIdentityAssociation",
+                "eks:DeletePodIdentityAssociation",
+                "eks:TagResource"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
## **Type**
enhancement, configuration changes


___

## **Description**
- Added a new IAM policy for EKS Pod Identity management and included it in the IAM role policy ARNs.
- Introduced a Crossplane Composition and CompositeResourceDefinition for managing EKS Pod Identity.
- Updated Crossplane provider configurations for AWS services (EC2, EKS, IAM, KMS, RDS, S3) and Kubernetes to newer versions.
- Registered the new EKS provider and updated the kustomization resources to include EPI composition and definition.
- Updated the `roleId` for the Vault cluster issuer in the cert-manager configuration.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>irsa.tf</strong><dd><code>Add EKS Pod Identity Management IAM Policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/irsa.tf
<li>Added a new IAM policy for managing EKS Pod identities.<br> <li> Included the new <code>crossplane_eks</code> policy ARN in the <code>role_policy_arns</code> <br>map.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-6139b02afc5fb5b6c1a30a2049c6d620565a7460bb9f27bccb84caf00fee203c">+25/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Update Kustomization with EPI Resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/configuration/kustomization.yaml
<li>Added <code>epi-composition.yaml</code> and <code>epi-definition.yaml</code> to the resources <br>list.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-a8e0ac867dc169f41d0e687fd48e52d44db9b0d9716bbb461ded754f918b82a6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Register EKS Provider in Kustomization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/kustomization.yaml
- Included `provider-eks.yaml` in the resources list.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-f7cee4b944adec03c09118b5f51deb4ec9d6d598abc9bbe7185bd079b6eccfcc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provider-ec2.yaml</strong><dd><code>Update AWS EC2 Provider Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/provider-ec2.yaml
- Updated the AWS EC2 provider package version to `v1.1.0`.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-89874e24aad68fb5066b2b226fc68b618e1005db63be26471fc1f6887e2d6924">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provider-iam.yaml</strong><dd><code>Update AWS IAM Provider Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/provider-iam.yaml
- Updated the AWS IAM provider package version to `v1.1.0`.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-af642c59487699855464ad5fc98aa8373388a4e5762cfcc50861a6495b304da7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provider-kms.yaml</strong><dd><code>Update AWS KMS Provider Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/provider-kms.yaml
- Updated the AWS KMS provider package version to `v1.1.0`.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-61f5fa1ca962af4d9e47cf8eaafbe5584cffff513728f670f9465d200e91ac1a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provider-kubernetes.yaml</strong><dd><code>Update Kubernetes Provider Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/provider-kubernetes.yaml
- Updated the Kubernetes provider package version to `v0.11.4`.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-aefd4e1c983f51156fe7204429b29cf2e575d0a705d1ea3ada53eaf75dc6c377">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provider-rds.yaml</strong><dd><code>Update AWS RDS Provider Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/provider-rds.yaml
- Updated the AWS RDS provider package version to `v1.1.0`.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-647031cae93bd470aa8bfb4968f787e20121b080b9fc6a14bee849add682bb5d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provider-s3.yaml</strong><dd><code>Update AWS S3 Provider Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/provider-s3.yaml
- Updated the AWS S3 provider package version to `v1.1.0`.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-58c0fedb33407672ede7dbb80a67bda6bd057513cfc9a567b8a2a2d8c5d01c6b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update Vault ClusterIssuer RoleId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml
- Updated the `roleId` for the Vault cluster issuer.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>epi-composition.yaml</strong><dd><code>Introduce EKS Pod Identity Composition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/configuration/epi-composition.yaml
<li>Introduced a new Crossplane Composition for EKS Pod Identity setup.<br> <li> Defined steps for IAM role, policy, and EKS Pod Identity Association <br>creation.<br> <li> Utilized patch sets and environment field paths for dynamic resource <br>configuration.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-cedc4b003a511502b9d5516cffc97792dfbddb69d378f8741288c252c8cdb145">+214/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>epi-definition.yaml</strong><dd><code>Define Composite Resource for EKS Pod Identity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/configuration/epi-definition.yaml
<li>Created a new CompositeResourceDefinition for EKS Pod Identity.<br> <li> Defined spec with parameters for cluster name, service account, and <br>policy document.<br> <li> Included status fields for association, role, and policy ARNs.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-0ad4ccd0ad9ae44b2c8275b1b7643fd351bee0d5f05c222bfe9f9e70ff1a2f2d">+96/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provider-eks.yaml</strong><dd><code>Add AWS EKS Provider Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/crossplane/providers/provider-eks.yaml
<li>Introduced a new provider configuration for AWS EKS with version <br><code>v1.1.0</code>.


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/137/files#diff-a3fad7eae18156af62122f058541997f459e86e4998a0ca703c78fb7cb7c32c4">+10/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
