### PR TITLE
docs: specify that either irsa or epi can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This diagram can be hard to understand so these are the key information:
 
 * **Namespaces** are the first resources to be created, all other resources may be namespace scoped
 * **CRDs** that allow to extend Kubernetes capabilities must be present in order to use them in all other applications when needed.
-* **Crossplane** creates [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) permissions which are required by some components
+* **Crossplane** creates [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) or [EPI](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) permissions which are required by some components
 * **Security** defines `external-secrets` that are needed by some applications in order to start.
 
 ## 🏗️ Crossplane configuration


### PR DESCRIPTION
## **User description**
Specify that either IRSA or EPI can be used


___

## **Type**
documentation


___

## **Description**
- Updated the README to clarify that Crossplane can create either IRSA or EPI permissions, providing flexibility in permissions setup for components.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to Include EPI Permissions Option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
<li>Clarified that Crossplane creates either IRSA or EPI permissions <br>required by some components.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/142/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

