### PR TITLE
feat(eks): use of AL2023 AMIs

### DIFF
--- a/terraform/eks/karpenter.tf
+++ b/terraform/eks/karpenter.tf
@@ -71,7 +71,7 @@ resource "kubectl_manifest" "karpenter_ec2_nodeclass" {
     metadata:
       name: default
     spec:
-      amiFamily: AL2
+      amiFamily: AL2023
       # instanceStorePolicy: "RAID0"
       role: ${module.karpenter.node_iam_role_name}
       subnetSelectorTerms:

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -68,10 +68,24 @@ module "eks" {
       max_size     = 3
       desired_size = 2
 
-      # Bottlerocket
-      use_custom_launch_template = false
-      ami_type                   = "BOTTLEROCKET_x86_64"
-      platform                   = "bottlerocket"
+      platform = "al2023"
+
+      cloudinit_pre_nodeadm = [
+        {
+          content_type = "application/node.eks.aws"
+          content      = <<-EOT
+            ---
+            apiVersion: node.eks.aws/v1alpha
+            kind: NodeConfig
+            spec:
+              kubelet:
+                config:
+                  shutdownGracePeriod: 30s
+                  featureGates:
+                    DisableKubeletCloudCredentialProviders: true
+          EOT
+        }
+      ]
 
       capacity_type        = "SPOT"
       force_update_version = true

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -41,7 +41,7 @@ variable "cilium_version" {
 
 variable "karpenter_version" {
   description = "Karpenter version"
-  default     = "v0.34.0"
+  default     = "0.35.0"
   type        = string
 }
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the AMI family for Karpenter to use Amazon Linux 2023 (AL2023), enhancing the infrastructure's compatibility and security.
- Removed the Bottlerocket configuration in favor of AL2023, including the addition of `cloudinit_pre_nodeadm` to configure nodes specifically for AL2023.
- Updated the Karpenter version to `0.35.0`, ensuring compatibility with the latest features and fixes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>karpenter.tf</strong><dd><code>Update AMI Family to AL2023 in Karpenter Configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/karpenter.tf
- Updated `amiFamily` from `AL2` to `AL2023`.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/151/files#diff-2d4d825842debc46c962f96774c4f140e2eb1a264c853e161c69d47e283ef456">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Configure EKS Nodes for AL2023 and Remove Bottlerocket Config</code></dd></summary>
<hr>

terraform/eks/main.tf
<li>Changed platform to <code>al2023</code>.<br> <li> Removed Bottlerocket configuration.<br> <li> Added <code>cloudinit_pre_nodeadm</code> configuration for <code>al2023</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/151/files#diff-417ec24690b4cefab94c36369121105f6a398a3640e69aab37f04c36bd48840d">+18/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update Karpenter Version to 0.35.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/variables.tf
- Updated `karpenter_version` from `v0.34.0` to `0.35.0`.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/151/files#diff-03a38e8def3f0b3f9d73cf5d2448da8616011aac36679094c516236136f19afd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

