### PR TITLE
Revert "feat(eks): use of AL2023 AMIs"

### DIFF
--- a/terraform/eks/karpenter.tf
+++ b/terraform/eks/karpenter.tf
@@ -71,7 +71,7 @@ resource "kubectl_manifest" "karpenter_ec2_nodeclass" {
     metadata:
       name: default
     spec:
-      amiFamily: AL2023
+      amiFamily: AL2
       # instanceStorePolicy: "RAID0"
       role: ${module.karpenter.node_iam_role_name}
       subnetSelectorTerms:

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -68,24 +68,10 @@ module "eks" {
       max_size     = 3
       desired_size = 2
 
-      platform = "al2023"
-
-      cloudinit_pre_nodeadm = [
-        {
-          content_type = "application/node.eks.aws"
-          content      = <<-EOT
-            ---
-            apiVersion: node.eks.aws/v1alpha
-            kind: NodeConfig
-            spec:
-              kubelet:
-                config:
-                  shutdownGracePeriod: 30s
-                  featureGates:
-                    DisableKubeletCloudCredentialProviders: true
-          EOT
-        }
-      ]
+      # Bottlerocket
+      use_custom_launch_template = false
+      ami_type                   = "BOTTLEROCKET_x86_64"
+      platform                   = "bottlerocket"
 
       capacity_type        = "SPOT"
       force_update_version = true

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -41,7 +41,7 @@ variable "cilium_version" {
 
 variable "karpenter_version" {
   description = "Karpenter version"
-  default     = "0.35.0"
+  default     = "v0.34.0"
   type        = string
 }
 


### PR DESCRIPTION
## **User description**
Reverts Smana/demo-cloud-native-ref#151

Because of this issue: https://github.com/awslabs/amazon-eks-ami/issues/1678


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Reverted the AMI family for Karpenter from `AL2023` back to `AL2` due to compatibility issues.
- Removed configurations specific to `al2023` and switched the default node group to use Bottlerocket.
- Downgraded Karpenter version from `0.35.0` to `v0.34.0`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>karpenter.tf</strong><dd><code>Revert AMI Family to AL2 in Karpenter Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/karpenter.tf
- Changed `amiFamily` from `AL2023` back to `AL2`.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/158/files#diff-2d4d825842debc46c962f96774c4f140e2eb1a264c853e161c69d47e283ef456">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Switch Default Node Group to Use Bottlerocket</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/main.tf
<li>Removed <code>platform</code> configuration for <code>al2023</code>.<br> <li> Removed <code>cloudinit_pre_nodeadm</code> configuration specific to <code>al2023</code>.<br> <li> Added Bottlerocket configuration as the default AMI type and platform.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/158/files#diff-417ec24690b4cefab94c36369121105f6a398a3640e69aab37f04c36bd48840d">+4/-18</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Downgrade Karpenter Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/variables.tf
- Downgraded `karpenter_version` from `0.35.0` to `v0.34.0`.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/158/files#diff-03a38e8def3f0b3f9d73cf5d2448da8616011aac36679094c516236136f19afd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

