### PR TITLE
fix(vault): using ubuntu release mantic, package vault unavailable for lunar

### DIFF
--- a/terraform/eks/README.md
+++ b/terraform/eks/README.md
@@ -22,10 +22,10 @@ cluster_name = "mycluster-0" # Generated with petname
 
 github_owner    = "Smana"
 github_token    = <REDACTED>
-repository_name = "cilium-gateway-api"
+repository_name = "demo-cloud-native-ref"
 
 tags = {
-  GithubRepo = "cilium-gateway-api"
+  GithubRepo = "demo-cloud-native-ref"
   GithubOrg  = "Smana"
 }
 ```

--- a/terraform/eks/karpenter.tf
+++ b/terraform/eks/karpenter.tf
@@ -71,8 +71,8 @@ resource "kubectl_manifest" "karpenter_ec2_nodeclass" {
     metadata:
       name: default
     spec:
-      amiFamily: AL2
-      # instanceStorePolicy: "RAID0"
+      amiFamily: Bottlerocket
+#      instanceStorePolicy: "RAID0"
       role: ${module.karpenter.node_iam_role_name}
       subnetSelectorTerms:
         - tags:

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -41,7 +41,7 @@ variable "cilium_version" {
 
 variable "karpenter_version" {
   description = "Karpenter version"
-  default     = "v0.34.0"
+  default     = "v0.34.3"
   type        = string
 }
 

--- a/terraform/vault/cluster/README.md
+++ b/terraform/vault/cluster/README.md
@@ -100,7 +100,7 @@ This architecture balances performance, cost-efficiency, and resilience, embraci
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ami_filter"></a> [ami\_filter](#input\_ami\_filter) | List of maps used to create the AMI filter for the action runner AMI. | `map(list(string))` | <pre>{<br>  "name": [<br>    "ubuntu/images/hvm-ssd/ubuntu-lunar-23.04-amd64-server-*"<br>  ]<br>}</pre> | no |
+| <a name="input_ami_filter"></a> [ami\_filter](#input\_ami\_filter) | List of maps used to create the AMI filter for the action runner AMI. | `map(list(string))` | <pre>{<br>  "name": [<br>    "ubuntu/images/hvm-ssd-gp3/ubuntu-mantic-23.10-amd64-server-*"<br>  ]<br>}</pre> | no |
 | <a name="input_ami_owner"></a> [ami\_owner](#input\_ami\_owner) | Owner ID of the AMI | `string` | `"099720109477"` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name for which the certificate should be issued | `string` | n/a | yes |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | If true, allow to connect to the instances using AWS Systems Manager | `bool` | `false` | no |

--- a/terraform/vault/cluster/scripts/cloudinit-config.yaml
+++ b/terraform/vault/cluster/scripts/cloudinit-config.yaml
@@ -18,7 +18,7 @@ apt:
   sources:
     hashicorp.list:
       keyid: 798AEC654E5C15428C8E42EEAA16FCBCA621E701
-      source: "deb [arch=amd64] https://apt.releases.hashicorp.com lunar main"
+      source: "deb [arch=amd64] https://apt.releases.hashicorp.com mantic main"
 
 packages:
   - jq

--- a/terraform/vault/cluster/variables.tf
+++ b/terraform/vault/cluster/variables.tf
@@ -47,7 +47,7 @@ variable "ami_filter" {
   type        = map(list(string))
 
   default = {
-    name = ["ubuntu/images/hvm-ssd/ubuntu-lunar-23.04-amd64-server-*"]
+    name = ["ubuntu/images/hvm-ssd-gp3/ubuntu-mantic-23.10-amd64-server-*"]
   }
 }
 


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Updated Karpenter configuration to use `Bottlerocket` AMI family and bumped version to `v0.34.3`.
- Fixed Ubuntu release for Vault cluster by changing from `lunar` to `mantic`.
- Updated EKS README documentation to reflect new repository information.
- Adjusted CloudInit configuration for Vault to use the correct HashiCorp repository.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>karpenter.tf</strong><dd><code>Update Karpenter Node Class Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/karpenter.tf
<li>Changed <code>amiFamily</code> from <code>AL2</code> to <code>Bottlerocket</code>.<br> <li> Commented out <code>instanceStorePolicy</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/177/files#diff-2d4d825842debc46c962f96774c4f140e2eb1a264c853e161c69d47e283ef456">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Bump Karpenter Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/variables.tf
- Updated `karpenter_version` from `v0.34.0` to `v0.34.3`.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/177/files#diff-03a38e8def3f0b3f9d73cf5d2448da8616011aac36679094c516236136f19afd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Fix Ubuntu Release for Vault Cluster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/vault/cluster/variables.tf
<li>Updated AMI filter name for Ubuntu from <code>lunar</code> to <code>mantic</code> release.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/177/files#diff-0d993bad6f4f320a69b5bcdbef0cf8cb2886eb51b56cbe372c9f6e48431c02d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cloudinit-config.yaml</strong><dd><code>Update CloudInit Config for Vault Cluster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/vault/cluster/scripts/cloudinit-config.yaml
- Changed HashiCorp repository source from `lunar` to `mantic`.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/177/files#diff-b68a832c3f81ffd2cde5bf9472dec7759ea11e2d5c748aff35c3d9a9783e6524">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update EKS README with New Repository Info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/README.md
<li>Updated <code>repository_name</code> and <code>GithubRepo</code> tag from <code>cilium-gateway-api</code> to <br><code>demo-cloud-native-ref</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/177/files#diff-7ad87ffb2522993ed0b5e545d40352a8eb364f0790ba12dc2e8873816d89520d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

