### PR TITLE
fix(eks): remove deprecated kubectl provider

### DIFF
--- a/terraform/eks/versions.tf
+++ b/terraform/eks/versions.tf
@@ -15,8 +15,8 @@ terraform {
       version = ">= 2.20"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14.0"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.0"
     }
     flux = {
       source  = "fluxcd/flux"


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the `kubectl` provider in the Terraform EKS module to use a new source and version, improving compatibility and addressing deprecation issues.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versions.tf</strong><dd><code>Update kubectl provider in Terraform EKS module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/versions.tf
<li>Updated the <code>kubectl</code> provider source from <code>gavinbunney/kubectl</code> to <br><code>alekc/kubectl</code>.<br> <li> Bumped the <code>kubectl</code> provider version requirement from <code>>= 1.14.0</code> to <code>>= </code><br><code>2.0.0</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/181/files#diff-0e45aec9d006db796612c3143a7678e1b5580be4937678623899b8671fede1e6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

