### PR TITLE
fix: use AL2023 instead of Bottlerocket for cilium to work

### DIFF
--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: b4ac95a4-a1a8-b896-7e3f-d8b0053e7c18 # !! This value changes each time I recreate the whole platform
+        roleId: 19a87ba6-3e33-1a98-08fc-34a2fed90d9c # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secretId

--- a/terraform/eks/README.md
+++ b/terraform/eks/README.md
@@ -2,7 +2,7 @@
 
 * Create a management EKS cluster in a single zone
 * Use SPOT instances
-* Use bottlerocket AMI
+* Use AL2023 AMI
 * Install and configure Karpenter
 * Install and configure Flux
 * Write a secret that contains the cluster's specific variables that will be used with Flux. (please refer to [variables substitutions](https://fluxcd.io/flux/components/kustomize/kustomization/#post-build-variable-substitution))

--- a/terraform/eks/flux.tf
+++ b/terraform/eks/flux.tf
@@ -25,6 +25,14 @@ resource "kubernetes_namespace" "flux_system" {
   metadata {
     name = "flux-system"
   }
+
+  # Ignore changes to labels to avoid because they are modified by Flux bootstrap.
+  lifecycle {
+    ignore_changes = [
+      metadata[0].labels,
+    ]
+  }
+
   depends_on = [module.eks]
 }
 

--- a/terraform/eks/karpenter.tf
+++ b/terraform/eks/karpenter.tf
@@ -71,8 +71,8 @@ resource "kubectl_manifest" "karpenter_ec2_nodeclass" {
     metadata:
       name: default
     spec:
-      amiFamily: Bottlerocket
-#      instanceStorePolicy: "RAID0"
+      amiFamily: "AL2023"
+      instanceStorePolicy: "RAID0"
       role: ${module.karpenter.node_iam_role_name}
       subnetSelectorTerms:
         - tags:

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -75,10 +75,26 @@ module "eks" {
       max_size     = 3
       desired_size = 2
 
-      # Bottlerocket
-      use_custom_launch_template = false
-      ami_type                   = "BOTTLEROCKET_x86_64"
-      platform                   = "bottlerocket"
+      ami_type = "AL2023_x86_64_STANDARD"
+
+      use_latest_ami_release_version = true
+
+      cloudinit_pre_nodeadm = [
+        {
+          content_type = "application/node.eks.aws"
+          content      = <<-EOT
+            ---
+            apiVersion: node.eks.aws/v1alpha1
+            kind: NodeConfig
+            spec:
+              kubelet:
+                config:
+                  shutdownGracePeriod: 30s
+                  featureGates:
+                    DisableKubeletCloudCredentialProviders: true
+          EOT
+        }
+      ]
 
       capacity_type        = "SPOT"
       force_update_version = true


### PR DESCRIPTION
### **User description**
Fixes https://github.com/Smana/demo-cloud-native-ref/issues/251


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Updated EKS worker nodes and Karpenter EC2 NodeClass to use AL2023 AMI instead of Bottlerocket.
- Added lifecycle block to ignore label changes in Flux namespace resource.
- Updated Vault ClusterIssuer configuration with new `roleId`.
- Updated README documentation to reflect the change to AL2023 AMI.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flux.tf</strong><dd><code>Ignore label changes in Flux namespace resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/flux.tf
<li>Added lifecycle block to ignore changes to labels in <br><code>kubernetes_namespace</code> resource.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/252/files#diff-176314779acb540b6ac35c0905488945c7ecd4b361ff680f79c172c6af3ade31">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>karpenter.tf</strong><dd><code>Update Karpenter EC2 NodeClass to use AL2023 AMI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/karpenter.tf
<li>Changed <code>amiFamily</code> from Bottlerocket to AL2023 in <br><code>karpenter_ec2_nodeclass</code> resource.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/252/files#diff-2d4d825842debc46c962f96774c4f140e2eb1a264c853e161c69d47e283ef456">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Switch EKS worker nodes to AL2023 AMI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/main.tf
<li>Changed <code>ami_type</code> from Bottlerocket to AL2023.<br> <li> Added <code>use_latest_ami_release_version</code> attribute.<br> <li> Added <code>cloudinit_pre_nodeadm</code> configuration for AL2023.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/252/files#diff-417ec24690b4cefab94c36369121105f6a398a3640e69aab37f04c36bd48840d">+20/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update roleId in Vault ClusterIssuer configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml
- Updated `roleId` in Vault ClusterIssuer configuration.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/252/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to reflect AL2023 AMI usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/README.md
<li>Updated documentation to reflect the use of AL2023 AMI instead of <br>Bottlerocket.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/252/files#diff-7ad87ffb2522993ed0b5e545d40352a8eb364f0790ba12dc2e8873816d89520d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

