### PR TITLE
fix: use AL2 instead of Bottlerocket in order for Cilium to work

### DIFF
--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: b4ac95a4-a1a8-b896-7e3f-d8b0053e7c18 # !! This value changes each time I recreate the whole platform
+        roleId: 6ddca779-62c0-71e8-27b3-9ea168d06023 # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secretId

--- a/terraform/eks/README.md
+++ b/terraform/eks/README.md
@@ -2,7 +2,7 @@
 
 * Create a management EKS cluster in a single zone
 * Use SPOT instances
-* Use bottlerocket AMI
+* Use Amazon Linux AMI (Currently Bottlerocket doesn't work and having issues with AL2023)
 * Install and configure Karpenter
 * Install and configure Flux
 * Write a secret that contains the cluster's specific variables that will be used with Flux. (please refer to [variables substitutions](https://fluxcd.io/flux/components/kustomize/kustomization/#post-build-variable-substitution))

--- a/terraform/eks/flux.tf
+++ b/terraform/eks/flux.tf
@@ -25,6 +25,14 @@ resource "kubernetes_namespace" "flux_system" {
   metadata {
     name = "flux-system"
   }
+
+  # Ignore changes to labels to avoid because they are modified by Flux bootstrap.
+  lifecycle {
+    ignore_changes = [
+      metadata[0].labels,
+    ]
+  }
+
   depends_on = [module.eks]
 }
 

--- a/terraform/eks/karpenter.tf
+++ b/terraform/eks/karpenter.tf
@@ -71,8 +71,8 @@ resource "kubectl_manifest" "karpenter_ec2_nodeclass" {
     metadata:
       name: default
     spec:
-      amiFamily: Bottlerocket
-#      instanceStorePolicy: "RAID0"
+      amiFamily: "AL2"
+      # instanceStorePolicy: "RAID0"
       role: ${module.karpenter.node_iam_role_name}
       subnetSelectorTerms:
         - tags:

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -75,10 +75,7 @@ module "eks" {
       max_size     = 3
       desired_size = 2
 
-      # Bottlerocket
-      use_custom_launch_template = false
-      ami_type                   = "BOTTLEROCKET_x86_64"
-      platform                   = "bottlerocket"
+      ami_type = "AL2_x86_64"
 
       capacity_type        = "SPOT"
       force_update_version = true


### PR DESCRIPTION
### **PR Type**
Bug fix, Documentation


___

### **Description**
- Switched EKS worker nodes from Bottlerocket to Amazon Linux 2 in `main.tf` and `karpenter.tf`.
- Added lifecycle block to ignore label changes in `flux-system` namespace.
- Updated `roleId` in Vault `ClusterIssuer` configuration.
- Added new Flux `GitRepository` and `Kustomization` manifests.
- Updated README to reflect the switch from Bottlerocket to Amazon Linux 2.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Switch EKS worker nodes from Bottlerocket to Amazon Linux 2.</code></dd></summary>
<hr>

terraform/eks/main.tf
<li>Changed <code>ami_type</code> from <code>BOTTLEROCKET_x86_64</code> to <code>AL2_x86_64</code>.<br> <li> Removed <code>use_custom_launch_template</code> and <code>platform</code> attributes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/254/files#diff-417ec24690b4cefab94c36369121105f6a398a3640e69aab37f04c36bd48840d">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>karpenter.tf</strong><dd><code>Update Karpenter configuration to use Amazon Linux 2.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/karpenter.tf
<li>Updated <code>amiFamily</code> from <code>Bottlerocket</code> to <code>AL2</code>.<br> <li> Commented out <code>instanceStorePolicy</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/254/files#diff-2d4d825842debc46c962f96774c4f140e2eb1a264c853e161c69d47e283ef456">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update roleId in Vault ClusterIssuer configuration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml
- Updated `roleId` in Vault `ClusterIssuer` configuration.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/254/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flux.tf</strong><dd><code>Ignore label changes in Flux system namespace.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/flux.tf
<li>Added lifecycle block to ignore changes to labels in <code>flux-system</code> <br>namespace.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/254/files#diff-176314779acb540b6ac35c0905488945c7ecd4b361ff680f79c172c6af3ade31">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gotk-sync.yaml</strong><dd><code>Add Flux GitRepository and Kustomization manifests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clusters/mycluster-0/flux-system/gotk-sync.yaml
- Added new Flux `GitRepository` and `Kustomization` manifests.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/254/files#diff-7c786712425fc16e05c70e441dacc8f3641371ba4b308d216e298b0fb2bed98a">+27/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Add Kustomization manifest for Flux.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clusters/mycluster-0/flux-system/kustomization.yaml
- Added new Kustomization manifest for Flux.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/254/files#diff-d66e48138dfb49082f730b653910bfb2649f85569de0e57b18945db3885ee99d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to reflect Amazon Linux 2 usage.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/README.md
<li>Updated documentation to reflect the switch from Bottlerocket to <br>Amazon Linux 2.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/254/files#diff-7ad87ffb2522993ed0b5e545d40352a8eb364f0790ba12dc2e8873816d89520d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

