### PR TITLE
chore: upgrade eks 1.30 and karpenter 0.37.0

### DIFF
--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: 6ddca779-62c0-71e8-27b3-9ea168d06023 # !! This value changes each time I recreate the whole platform
+        roleId: daabf5fd-cc71-446c-8648-a7586bc89ed0 # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secretId

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -17,7 +17,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   description = "k8s cluster version"
-  default     = "1.29"
+  default     = "1.30"
   type        = string
 }
 
@@ -41,7 +41,7 @@ variable "cilium_version" {
 
 variable "karpenter_version" {
   description = "Karpenter version"
-  default     = "0.36.1"
+  default     = "0.37.0"
   type        = string
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Other


___

### **Description**
- Upgraded EKS cluster version from `1.29` to `1.30` in `terraform/eks/variables.tf`.
- Updated Karpenter version from `0.36.1` to `0.37.0` in `terraform/eks/variables.tf`.
- Updated `roleId` value for Vault AppRole authentication in `security/base/cert-manager/vault-clusterissuer.yaml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Upgrade EKS and Karpenter versions in Terraform variables</code></dd></summary>
<hr>

terraform/eks/variables.tf
<li>Upgraded EKS cluster version from <code>1.29</code> to <code>1.30</code>.<br> <li> Updated Karpenter version from <code>0.36.1</code> to <code>0.37.0</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/271/files#diff-03a38e8def3f0b3f9d73cf5d2448da8616011aac36679094c516236136f19afd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Other
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update Vault AppRole `roleId` in cert-manager configuration</code></dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml
- Updated `roleId` value for Vault AppRole authentication.



</details>
    

  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/271/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

