### PR TITLE
chore(ci): disable dagger cloud in order to allow anyone to see the C…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           verb: call
           module: github.com/Smana/daggerverse/pre-commit-tf@pre-commit-tf/v0.0.1
           args: run --dir "." --tf-binary="tofu"
-          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          # cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
   kubernetes-validation:
     name: Kubernetes validation ☸
@@ -44,7 +44,7 @@ jobs:
           verb: call
           module: github.com/Smana/daggerverse/kubeconform@kubeconform/v0.0.4
           args: validate --manifests "./clusters" --catalog
-          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          # cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
       - name: Validate Kubernetes manifests (Kustomize directories)
         uses: dagger/dagger-for-github@v5
@@ -53,4 +53,4 @@ jobs:
           verb: call
           module: github.com/Smana/daggerverse/kubeconform@kubeconform/v0.0.4
           args: validate --manifests "." --kustomize --flux --env="cluster_name:foobar,region:eu-west-3,domain_name:example.com" --catalog --crds https://github.com/kubernetes-sigs/gateway-api/tree/main/config/crd/experimental
-          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          # cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
### **User description**
…I results without having to sign-in


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Disabled the Dagger Cloud token in the CI workflow by commenting out the `cloud-token` parameter in multiple steps.
- This change allows anyone to see the CI results without having to sign in.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>Disable Dagger Cloud token in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<li>Commented out the <code>cloud-token</code> parameter in multiple steps.<br> <li> Aimed to disable Dagger Cloud token usage.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/329/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

