### PR TITLE
docs(dagger): add link to the blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This repository provides a comprehensive guide and set of tools for building, ma
     - [🏠 Using Self-Hosted Runners](#-using-self-hosted-runners)
       - [Overview](#overview-1)
       - [Enabling Self-Hosted Runners](#enabling-self-hosted-runners)
-      - [Dagger example with Self-Hosted Runners](#dagger-example-with-self-hosted-runners)
 
 ## 🌟 Overview
 
@@ -144,33 +143,4 @@ This feature can be enabled within the `tooling` kustomization. By leveraging se
 
 For detailed information on setting up and using GitHub Self-Hosted Runners, please refer to this [documentation](https://docs.github.com/en/actions/hosting-your-own-runners).
 
-#### Dagger example with Self-Hosted Runners
-
-```yaml
-name: Cache testing
-
-on:
-  pull_request:
-  push:
-    branches: ["main"]
-
-jobs:
-
-  test-cache:
-    name: Testing in-cluster cache
-    runs-on: dagger-gha-runner-scale-set
-    container:
-      image: smana/dagger-cli:v0.11.9
-    env:
-      _EXPERIMENTAL_DAGGER_RUNNER_HOST: "tcp://dagger-engine:8080"
-      cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-
-    steps:
-      - name: Simulate a build with heavy packages
-        uses: dagger/dagger-for-github@v5
-        with:
-          version: "latest"
-          verb: call
-          module: github.com/shykes/daggerverse.git/wolfi@dfb1f91fa463b779021d65011f0060f7decda0ba
-          args: container --packages "python3,py3-pip,go,rust,clang"
-```
+🏷️ Related blog post: Dagger: [The missing piece of the developer experience](https://blog.ogenki.io/post/dagger-intro/)


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Removed the 'Dagger example with Self-Hosted Runners' section from the README.
- Added a link to the blog post titled 'The missing piece of the developer experience' about Dagger in the README.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with Dagger blog post link and remove example</code></dd></summary>
<hr>

README.md

<li>Removed the 'Dagger example with Self-Hosted Runners' section.<br> <li> Added a link to a related blog post about Dagger.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/demo-cloud-native-ref/pull/331/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-31</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

